### PR TITLE
ASSIGN-KEY should take a Mu value

### DIFF
--- a/lib/Hash/Agnostic.pm6
+++ b/lib/Hash/Agnostic.pm6
@@ -54,7 +54,7 @@ role Hash::Agnostic:ver<0.0.8>:auth<cpan:ELIZABETH>
         self.DELETE-KEY($_) for self.keys;
     }
 
-    method ASSIGN-KEY(::?ROLE:D: $key, \value) is raw {
+    method ASSIGN-KEY(::?ROLE:D: $key, Mu \value) is raw {
         self.AT-KEY($key) = value;
     }
 


### PR DESCRIPTION
... or at least, that's how it's done throughout the Rakudo source, and this makes some of my code work that requires Mu as a hash value.
